### PR TITLE
render the run header in output

### DIFF
--- a/internal/dispatch/shared.go
+++ b/internal/dispatch/shared.go
@@ -110,6 +110,8 @@ func renderRun(out io.Writer, cs *iostreams.ColorScheme, client api.RESTClient, 
 		return nil, fmt.Errorf("failed to get run: %w", err)
 	}
 
+	run.workflowName = ""
+
 	jobs, err := getJobs(client, repo, run.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get jobs: %w", err)
@@ -139,6 +141,7 @@ func renderRun(out io.Writer, cs *iostreams.ColorScheme, client api.RESTClient, 
 		return nil, fmt.Errorf("failed to get annotations: %w", annotationErr)
 	}
 
+	fmt.Fprintln(out, shared.RenderRunHeader(cs, *run, "", ""))
 	fmt.Fprintln(out)
 
 	if len(jobs) == 0 {


### PR DESCRIPTION
This is a WIP attempt to address issue #19.

Note that it is impacted by https://github.com/cli/cli/issues/6626.